### PR TITLE
Add data caching to avoid redundant downloads and re-parsing

### DIFF
--- a/src/ttab_downloader.py
+++ b/src/ttab_downloader.py
@@ -228,18 +228,25 @@ class TTABDownloader:
             
             # Skip if file already exists and not forcing redownload
             if not force_redownload:
-                # Check if ZIP file exists
-                if output_path.exists():
-                    logger.info(f"ZIP file already exists, skipping: {filename}")
-                    return True
-                
                 # Check if extracted XML file exists (for .zip files)
                 if filename.lower().endswith('.zip'):
-                    # Derive XML filename from ZIP filename
                     xml_filename = filename[:-4] + '.xml'  # Replace .zip with .xml
                     xml_path = self.output_dir / xml_filename
                     if xml_path.exists():
                         logger.info(f"Extracted XML already exists, skipping download: {xml_filename}")
+                        return True
+
+                # Check if ZIP file exists and its size matches the API-reported size
+                if output_path.exists():
+                    if file_size and output_path.stat().st_size != file_size:
+                        logger.warning(
+                            f"ZIP file size mismatch for {filename} "
+                            f"(on disk: {output_path.stat().st_size:,}, expected: {file_size:,}) "
+                            f"— re-downloading"
+                        )
+                        output_path.unlink()
+                    else:
+                        logger.info(f"ZIP file already exists, skipping: {filename}")
                         return True
             
             logger.info(f"Downloading: {filename} ({file_size:,} bytes)")


### PR DESCRIPTION
- ttab_parser.py: introduce ParseStateManager that records each XML
  file's mtime in <input_dir>/.parse_state.json after a successful
  parse run; subsequent runs skip unchanged files automatically.
  Add --force / -f flag to bypass the cache when a full re-parse is
  needed.

- courtlistener_client.py: add _load_from_db() that checks the local
  PostgreSQL DB for an existing FederalCircuitAppealRecord before
  calling the CourtListener API.  Re-runs with a configured database
  never re-query CourtListener for already-enriched cases.

- ttab_downloader.py: validate on-disk ZIP file size against the size
  reported by the USPTO API; re-download if they differ, catching
  partial/corrupted downloads that would otherwise be silently skipped.
  The extracted-XML check is now tested before the ZIP check so a
  complete prior run is detected even when the ZIP was already removed.

https://claude.ai/code/session_01D2R2MozRBycKTT5athUJP7